### PR TITLE
ExampleHotkeys.ahk: Handle null values

### DIFF
--- a/Example Hotkeys.ahk
+++ b/Example Hotkeys.ahk
@@ -23,6 +23,7 @@ return
 
 F1::
 if(VolumePercentage == "")
+  HandleUnknownVolume()
   return
 if(VolumePercentage - Increment > 0)
   VolumePercentage := VolumePercentage - Increment
@@ -31,6 +32,7 @@ return
 
 F2::
 if(VolumePercentage == "")
+  HandleUnknownVolume()
   return
 if(VolumePercentage + Increment <= 100)
   VolumePercentage := VolumePercentage + Increment
@@ -55,3 +57,7 @@ F6::
 spoofy.Player.LastTrack()
 return 
 
+HandleUnknownVolume() {
+  MsgBox, "Current volume is unknown. The script will be reloaded."
+  Reload
+}

--- a/Example Hotkeys.ahk
+++ b/Example Hotkeys.ahk
@@ -22,12 +22,16 @@ RepeatMode := (PlaybackInfo.repeat_state = "context" ? 2 : PlaybackInfo.repeat_s
 return
 
 F1::
+if(VolumePercentage == "")
+  return
 if(VolumePercentage - Increment > 0)
   VolumePercentage := VolumePercentage - Increment
 spoofy.Player.SetVolume(VolumePercentage) ; Decrement the volume percentage and set the player to the new volume percentage
 return
 
 F2::
+if(VolumePercentage == "")
+  return
 if(VolumePercentage + Increment <= 100)
   VolumePercentage := VolumePercentage + Increment
 spoofy.Player.SetVolume(VolumePercentage) ; Increment the volume percentage and set the player to the new volume percentage


### PR DESCRIPTION
The VolumePercentage returned by the Spotify API can be null, which sometimes causes errors.
This adds checks to prevent these errors.
If the VolumePercentage is null (or "" in AHK), a message is displayed and the script is reloaded.